### PR TITLE
feat: add table based styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,3 @@
 
 <a href="https://github.com/ashutosh00710/github-readme-activity-graph"><img alt="Prathamesh Kurunkar's Activity Graph" src="https://github-readme-activity-graph.vercel.app/graph/?username=prathameshkurunkar7&theme=tokyo-night&line=F85D7F&point=FFFFFF&hide_border=true" /></a>
 
-<div style="display: flex; flex-direction: column; gap: 8px">
-
-<a href="https://thecommit.company//blog/culture/transitioning-from-mnc-to-startup-my-experience-at-the-commit-company" target="_blank" style="text-decoration: none !important; color: inherit !important;">
-<div style="display: flex; align-items: center; border-radius: 4px; border: 1px solid #30363d; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); overflow: hidden; max-height: 200px;">
-<div style="max-width: 33.33%;">
-<img src="https://thecommit.company/files/a-juxtaposition-of-a-bustling-multinational-corporation-office-transitioning-to-a-cozy-dynamic-star.jpeg" alt="Transitioning from MNC to Startup: My Experience @ The Commit Company" style="width: 100%; border-radius:4px">
-</div>
-<div style="padding: 16px;">
-<h2 style="font-size: 18px; font-weight: bold; margin-bottom: 10px;">Transitioning from MNC to Startup: My Experience @ The Commit Company</h2>
-<p style="font-size: 14px; line-height: 1.5; margin-bottom: 14px;">Breaking out from comfort zone, I embarked on an exhilarating journey from MNC to startup at The Commit Company.</p>
-</div>
-</div>
-</a>
-</div>

--- a/render_blog_data.py
+++ b/render_blog_data.py
@@ -11,24 +11,21 @@ def render_blog_data():
     # Formatting of the function below is avoided to avoid extra spacing being generated in markdown
     def generate_blog_card(blog):
         return f"""\n
-<a href="{blog["url"]}" target="_blank" style="text-decoration: none !important; color: inherit !important;">
-<div style="display: flex; align-items: center; border-radius: 4px; border: 1px solid #30363d; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); overflow: hidden; max-height: 200px;">
-<div style="max-width: 33.33%;">
-<img src="{blog["meta_image"]}" alt="{blog["title"]}" style="width: 100%; border-radius:4px">
-</div>
-<div style="padding: 16px;">
-<h2 style="font-size: 18px; font-weight: bold; margin-bottom: 10px;">{blog["title"]}</h2>
-<p style="font-size: 14px; line-height: 1.5; margin-bottom: 14px;">{blog["meta_description"]}</p>
-</div>
-</div>
-</a>\n"""
+<table>
+  <tr>
+    <th align="left" colspan="2"><a href="{blog['url']}">{blog['title']}</a></th>
+  </tr>
+  <tr>
+    <td width="20%"><a href="{blog['url']}"><img src="{blog['meta_image']}" alt="{blog['title']}" width="100%"></a></td>
+    <td width="80%">{blog['meta_description']}</td>
+  </tr>
+</table>
+\n"""
 
 
     # Generate the markdown for all blog cards
     rendered_cards = ''.join([generate_blog_card(blog) for blog in blog_data])
 
-    # Wrap the rendered cards in a container
-    rendered_cards = f'<div style="display: flex; flex-direction: column; gap: 8px">{rendered_cards}</div>'
 
     # Append the rendered cards to the README file
     with open('README.md', 'a') as f:


### PR DESCRIPTION
- Found out that even inline css is removed by Github in previews for security reasons, hence the cards weren't getting styled in here(worked on other readme preview though.)
- Tried SVG based styling after reading some articles, even that does not work.
- Tried headless browser and screenshot method, but did not give satisfactory results, hence came back to basic table like styling to render blogs.